### PR TITLE
1 re enable screen saver

### DIFF
--- a/main/AppContext.cpp
+++ b/main/AppContext.cpp
@@ -93,6 +93,7 @@ namespace ctx
       }
       if (mModel.mTimeZone != "")
       {
+        delay(100);  // trying to avoid ntp occasionally corrupting heap on startup
         mNTPSync = std::make_shared<ntp::NTPSync>(mModel.mTimeZone);
         mNTPSync->syncTime();
       }

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -8,6 +8,8 @@
 #include <touch/TouchDriver.h>
 #include <util/varianthelper.hpp>
 
+#include <SharedGlobalState.h>
+
 #include "Arduino.h"
 #include "SPI.h"
 
@@ -22,6 +24,8 @@ extern "C"
 
 namespace gfx
 {
+  //std::shared_ptr<sgs::SharedGlobalState> global_state = sgs::SharedGlobalState::getInstance();
+
   static const int kStatusBarHeight = 20;
 
   template<class ScreenDriver, class NavigationDriver>

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -166,7 +166,11 @@ namespace gfx
     std::lock_guard<std::mutex> guard(viewMutex);
     auto tapEvent = mNavigation.tapEvent();
     // FIXME: screen saver is broken - activates on touch and not on timeout (automatically) and does not deactivate 
-    // mScreenSaver();
+    if(mScreenSaver()){
+      // screen saver returned IGNORE_TOUCH_ON_WAKEUP
+      return;
+    }
+
 
     // // Abort when Screensaver is on and no touch event happened.
     // if (!mScreenSaver.tapped(tapEvent))

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -87,6 +87,7 @@ set(PLATFORM_SRC
 set(COMPONENT_SRCS 
     "AppContext.cpp"
     "main.cpp"
+    "SharedGlobalState.cpp"
     ${FS_SRC}
     ${UI_SRC}
     ${MQTT_SRC}

--- a/main/SharedGlobalState.cpp
+++ b/main/SharedGlobalState.cpp
@@ -1,0 +1,32 @@
+#include "SharedGlobalState.h"
+#include <memory> 
+
+namespace sgs {
+// when using with C-compatible functions version
+SharedGlobalState& sharedGlobalState = SharedGlobalState::getInstance();
+
+// std::shared_ptr<SharedGlobalState> SharedGlobalState::getInstance() {
+//     static std::shared_ptr<SharedGlobalState> instance = std::make_shared<SharedGlobalState>();
+//     return instance;
+// }
+
+}
+
+// Implementation of C-compatible functions
+
+extern "C" {
+
+void* sharedGlobalStateGetInstance() {
+    return reinterpret_cast<void*>(&sgs::SharedGlobalState::getInstance());
+}
+
+int sharedGlobalStateGetUptime(void* instance) {
+    return static_cast<sgs::SharedGlobalState*>(instance)->getUptime();
+}
+
+void sharedGlobalStateTickUptimeMs(void* instance, int ms) {
+    static_cast<sgs::SharedGlobalState*>(instance)->tickUptimeMs(ms);
+}
+
+
+} // extern "C"

--- a/main/SharedGlobalState.h
+++ b/main/SharedGlobalState.h
@@ -13,7 +13,7 @@ namespace sgs {
 
 class SharedGlobalState {
 public:
-    SharedGlobalState() : uptime_sec(0), last_log_print_sec(0), uptime_ms(0), last_tap_ms(0) {}
+    SharedGlobalState() : uptime_sec(0), last_log_print_sec(0), uptime_ms(0), last_tap_ms(0), sec_since_last_tap(0) {}
     
     // when using with C-compatible functions version
     static SharedGlobalState& getInstance() {
@@ -26,11 +26,12 @@ public:
         std::lock_guard<std::mutex> lock(mutex);
         uptime_ms += static_cast<long>(ms);
         uptime_sec = std::floor(static_cast<double>(uptime_ms)/1000.0);
+        sec_since_last_tap = static_cast<int>(std::floor((uptime_ms - last_tap_ms) / 1000.0));
+
         if (uptime_sec % 5 == 0){
             if(uptime_sec != last_log_print_sec){
-                ESP_LOGI("SharedGlobalState", "uptime %d sec", uptime_sec);
-                long sec_since_last_tap = std::floor((uptime_ms - last_tap_ms) / 1000.0);
-                ESP_LOGI("SharedGlobalState", "sec_since_last_tap  %d sec", static_cast<int>(sec_since_last_tap));
+                ESP_LOGI("SharedGlobalState", "uptime %d sec", uptime_sec);        
+                ESP_LOGI("SharedGlobalState", "sec_since_last_tap  %d sec", sec_since_last_tap);
                 last_log_print_sec = uptime_sec;
             }
         }
@@ -44,6 +45,11 @@ public:
     int getUptime() const {
         std::lock_guard<std::mutex> lock(mutex);
         return uptime_sec;
+    }
+
+    int getIdleTimeSec() const {
+        std::lock_guard<std::mutex> lock(mutex);
+        return sec_since_last_tap;
     }
     
     void registerTap(){
@@ -59,6 +65,7 @@ private:
     int last_log_print_sec;
     long uptime_ms;
     long last_tap_ms;
+    int sec_since_last_tap;
     mutable std::mutex mutex;   // Note: mutable is used to allow locking in const member functions
 };
 

--- a/main/SharedGlobalState.h
+++ b/main/SharedGlobalState.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <cmath>
+
+extern "C" 
+{
+  #include "esp_log.h"
+}
+
+namespace sgs {
+
+class SharedGlobalState {
+public:
+    SharedGlobalState() : uptime_sec(0), last_log_print_sec(0), uptime_ms(0), last_tap_ms(0) {}
+    
+    // when using with C-compatible functions version
+    static SharedGlobalState& getInstance() {
+        static SharedGlobalState instance;
+        return instance;
+    }
+    //static std::shared_ptr<SharedGlobalState> getInstance();
+
+    void tickUptimeMs(int ms){
+        std::lock_guard<std::mutex> lock(mutex);
+        uptime_ms += static_cast<long>(ms);
+        uptime_sec = std::floor(static_cast<double>(uptime_ms)/1000.0);
+        if (uptime_sec % 5 == 0){
+            if(uptime_sec != last_log_print_sec){
+                ESP_LOGI("SharedGlobalState", "uptime %d sec", uptime_sec);
+                long sec_since_last_tap = std::floor((uptime_ms - last_tap_ms) / 1000.0);
+                ESP_LOGI("SharedGlobalState", "sec_since_last_tap  %d sec", static_cast<int>(sec_since_last_tap));
+                last_log_print_sec = uptime_sec;
+            }
+        }
+
+    }
+    void setUptime(int new_uptime) {
+        std::lock_guard<std::mutex> lock(mutex);
+        uptime_sec = new_uptime;
+    }
+
+    int getUptime() const {
+        std::lock_guard<std::mutex> lock(mutex);
+        return uptime_sec;
+    }
+    
+    void registerTap(){
+        std::lock_guard<std::mutex> lock(mutex);
+        
+        ESP_LOGI("SharedGlobalState", "registering tap");
+
+        last_tap_ms = uptime_ms;
+    }
+
+private:
+    int uptime_sec;
+    int last_log_print_sec;
+    long uptime_ms;
+    long last_tap_ms;
+    mutable std::mutex mutex;   // Note: mutable is used to allow locking in const member functions
+};
+
+// Define the shared instance
+extern SharedGlobalState& sharedGlobalState;
+
+} // namespace sgs

--- a/main/SharedGlobalState.h
+++ b/main/SharedGlobalState.h
@@ -9,67 +9,83 @@ extern "C"
   #include "esp_log.h"
 }
 
-namespace sgs {
+namespace sgs 
+{
+    static const char *LOG_TAG = "SharedGlobalState";
 
-class SharedGlobalState {
-public:
-    SharedGlobalState() : uptime_sec(0), last_log_print_sec(0), uptime_ms(0), last_tap_ms(0), sec_since_last_tap(0) {}
-    
-    // when using with C-compatible functions version
-    static SharedGlobalState& getInstance() {
-        static SharedGlobalState instance;
-        return instance;
-    }
-    //static std::shared_ptr<SharedGlobalState> getInstance();
+    class SharedGlobalState {
+    public:
+        SharedGlobalState() : uptime_sec(0), last_log_print_sec(0), uptime_ms(0), last_tap_ms(0), sec_since_last_tap(0) {}
+        
+        // when using with C-compatible functions version
+        static SharedGlobalState& getInstance() {
+            static SharedGlobalState instance;
+            return instance;
+        }
+        //static std::shared_ptr<SharedGlobalState> getInstance();
 
-    void tickUptimeMs(int ms){
-        std::lock_guard<std::mutex> lock(mutex);
-        uptime_ms += static_cast<long>(ms);
-        uptime_sec = std::floor(static_cast<double>(uptime_ms)/1000.0);
-        sec_since_last_tap = static_cast<int>(std::floor((uptime_ms - last_tap_ms) / 1000.0));
-
-        if (uptime_sec % 5 == 0){
-            if(uptime_sec != last_log_print_sec){
-                ESP_LOGI("SharedGlobalState", "uptime %d sec", uptime_sec);        
-                ESP_LOGI("SharedGlobalState", "sec_since_last_tap  %d sec", sec_since_last_tap);
-                last_log_print_sec = uptime_sec;
+        void tickUptimeMs(int ms){
+            std::lock_guard<std::mutex> lock(mutex);
+            uptime_ms += static_cast<long>(ms);
+            uptime_sec = std::floor(static_cast<double>(uptime_ms)/1000.0);
+            
+            // in case of uptime_ms overflow every 49.7 days the idle time is truncated to max 24h
+            if (last_tap_ms > uptime_ms)
+            {
+                ESP_LOGI(LOG_TAG, "uptime_ms overflow"); 
+                last_tap_ms = 0;
+                if (sec_since_last_tap < 24 * 3600)
+                {
+                    uptime_ms = sec_since_last_tap * 1000;
+                }
+                else{
+                    uptime_ms = 24 * 3600 * 1000;
+                }
             }
+            sec_since_last_tap = static_cast<int>(std::floor((uptime_ms - last_tap_ms) / 1000.0));
+
+            if (uptime_sec % 5 == 0){
+                if(uptime_sec != last_log_print_sec){
+                    ESP_LOGI(LOG_TAG, "uptime %d sec", uptime_sec);        
+                    ESP_LOGI(LOG_TAG, "sec_since_last_tap  %d sec", sec_since_last_tap);
+                    last_log_print_sec = uptime_sec;
+                }
+            }
+
+        }
+        void setUptime(int new_uptime) {
+            std::lock_guard<std::mutex> lock(mutex);
+            uptime_sec = new_uptime;
         }
 
-    }
-    void setUptime(int new_uptime) {
-        std::lock_guard<std::mutex> lock(mutex);
-        uptime_sec = new_uptime;
-    }
+        int getUptime() const {
+            std::lock_guard<std::mutex> lock(mutex);
+            return uptime_sec;
+        }
 
-    int getUptime() const {
-        std::lock_guard<std::mutex> lock(mutex);
-        return uptime_sec;
-    }
-
-    int getIdleTimeSec() const {
-        std::lock_guard<std::mutex> lock(mutex);
-        return sec_since_last_tap;
-    }
-    
-    void registerTap(){
-        std::lock_guard<std::mutex> lock(mutex);
+        int getIdleTimeSec() const {
+            std::lock_guard<std::mutex> lock(mutex);
+            return sec_since_last_tap;
+        }
         
-        ESP_LOGI("SharedGlobalState", "registering tap");
+        void registerTap(){
+            std::lock_guard<std::mutex> lock(mutex);
+            
+            ESP_LOGI("SharedGlobalState", "registering tap");
 
-        last_tap_ms = uptime_ms;
-    }
+            last_tap_ms = uptime_ms;
+        }
 
-private:
-    int uptime_sec;
-    int last_log_print_sec;
-    long uptime_ms;
-    long last_tap_ms;
-    int sec_since_last_tap;
-    mutable std::mutex mutex;   // Note: mutable is used to allow locking in const member functions
-};
+    private:
+        int uptime_sec;
+        int last_log_print_sec;
+        long uptime_ms;
+        long last_tap_ms;
+        int sec_since_last_tap;
+        mutable std::mutex mutex;   // Note: mutable is used to allow locking in const member functions
+    };
 
-// Define the shared instance
-extern SharedGlobalState& sharedGlobalState;
+    // Define the shared instance
+    extern SharedGlobalState& sharedGlobalState;
 
 } // namespace sgs

--- a/main/config/PlatformInject.hpp
+++ b/main/config/PlatformInject.hpp
@@ -42,6 +42,9 @@
   auto ScreenOnOffSwitch = [](ScreenDriver* driver, bool on, bool inverted = false)
   {
     driver->setSleep(!on);
+    auto axp = AXP192();
+    axp.SetDCDC3(!on);   // turn screen off / on
+    axp.SetLed(!on);
   };
   auto InitializeScreen = [](ScreenDriver* driver)
   {

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -6,6 +6,9 @@ extern "C"
   #include "esp_log.h"
 }
 
+
+#define LOG_TAG "config reader"
+
 namespace fs
 {
 
@@ -302,6 +305,7 @@ namespace fs
 
       read(document, "screenSaverMinutes", [&](int mins)
           {
+            ESP_LOGI(LOG_TAG,  "overriden mScreensaverMins to  %d min", mins);
             hwConfig.mScreensaverMins = mins;
           }
         );

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -309,6 +309,20 @@ namespace fs
             hwConfig.mScreensaverMins = mins;
           }
         );
+      
+      read(document, "screenSaverPowerSaveEnabled", [&](bool screenSaverPowerSaveEnabled)
+          {
+            ESP_LOGI(LOG_TAG,  "overriden screenSaverPowerSaveEnabled to  %d", screenSaverPowerSaveEnabled);
+            hwConfig.mIsScreenSaverPowerSaveEnabled = screenSaverPowerSaveEnabled;
+          }
+        );
+      
+      read(document, "powerSaveMHz", [&](int powerSaveMHz)
+          {
+            ESP_LOGI(LOG_TAG,  "overriden powerSaveMHz to  %d MHz", powerSaveMHz);
+            hwConfig.mPowerSaveFreq = powerSaveMHz;
+          }
+        );
 
       read(document, "screenRotationAngle", [&](int angle)
           {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -5,8 +5,10 @@
 #include <config/Config.h>
 #include <fs/ConfigReader.hpp>
 #include "AppScreen.hpp"
+#include "SharedGlobalState.h"
 
 #include <memory>
+#include "esp_log.h"
 
 extern "C"
 {
@@ -14,6 +16,7 @@ extern "C"
   #include "freertos/task.h"
   #include "esp_task_wdt.h"
   #include "nvs_flash.h"
+  
 }
 
 #define MAINLOOPCORE 0
@@ -22,11 +25,16 @@ bool loopTaskWDTEnabled = false; // Enable if watchdog running
 
 std::shared_ptr<ctx::AppContext> mpAppContext(new ctx::AppContext());
 gfx::AppScreen<ScreenDriver, NavigationDriver> mScreen(mpAppContext);
+//std::shared_ptr<sgs::SharedGlobalState> global_state = sgs::SharedGlobalState::getInstance();
 
 extern "C" 
 {
   void runLoop(void *pvParameters);
   void setupApp();
+  
+  void* sharedGlobalStateGetInstance();
+  void  sharedGlobalStateTickUptimeMs(void* instance, int ms);
+  void* sgs_instance = sharedGlobalStateGetInstance();
 
   void app_main()
   {
@@ -69,14 +77,21 @@ extern "C"
 
   void runLoop(void *pvParameters)
   {
+    //esp_log_level_set("*", ESP_LOG_INFO);
+    int loop_delay_ms = 50;
+    ESP_LOGI("main", "starting main loop");
+    
     for(;;)
     {
         if (loopTaskWDTEnabled)
         {
           esp_task_wdt_reset();
         }
+        
         mScreen.draw();
-        delay(50);
+        sharedGlobalStateTickUptimeMs(sgs_instance, loop_delay_ms);
+        //global_state->tickUptimeMs(loop_delay_ms);
+        delay(loop_delay_ms);
     }
   }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -21,7 +21,7 @@ extern "C"
 
 #define MAINLOOPCORE 0
 TaskHandle_t runLoopHandle = NULL;
-bool loopTaskWDTEnabled = false; // Enable if watchdog running
+bool loopTaskWDTEnabled = true; // Enable if watchdog running
 
 std::shared_ptr<ctx::AppContext> mpAppContext(new ctx::AppContext());
 gfx::AppScreen<ScreenDriver, NavigationDriver> mScreen(mpAppContext);
@@ -46,6 +46,9 @@ extern "C"
     ESP_ERROR_CHECK(ret);
 
     initArduino();
+    
+    setCpuFrequencyMhz(240);
+
     InitializePlatform();
     Serial.begin(115200);
     setupApp();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,9 +46,6 @@ extern "C"
     ESP_ERROR_CHECK(ret);
 
     initArduino();
-    
-    setCpuFrequencyMhz(240);
-
     InitializePlatform();
     Serial.begin(115200);
     setupApp();

--- a/main/model/HardwareConfig.hpp
+++ b/main/model/HardwareConfig.hpp
@@ -13,5 +13,8 @@ namespace config
     bool mIsTouchXAxisInverted = kTOUCH_X_AXIS_INVERTED;
     bool mIsTouchYAxisInverted = kTOUCH_Y_AXIS_INVERTED;
     bool mIsDisplayColorInverted = kDISPLAY_INVERTED;
+    bool mIsScreenSaverPowerSaveEnabled = true;
+    int mPowerSaveFreq = 80;
+    int mPerformanceFreq = 240;
   };
 }

--- a/main/tft/ScreenSaver.hpp
+++ b/main/tft/ScreenSaver.hpp
@@ -10,10 +10,10 @@
 
 #include <SharedGlobalState.h>
 
-#define LOG_TAG "screen saver"
-
 namespace gfx
 {
+  static const char *LOG_TAG = "screen saver";
+
   template<typename ScreenDriver>
   struct ScreenSaver
   {
@@ -87,16 +87,23 @@ namespace gfx
           ESP_LOGI(LOG_TAG,  "switching screen OFF, new mCurrentState: %d", new_screen_state);
           if (power_save_enabled)
           {
-            ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", power_save_freq_mhz);
-            setCpuFrequencyMhz(power_save_freq_mhz);
+            ESP_LOGI(LOG_TAG,  "enabling power save features");
+            WiFi.setSleep(true);
+            //delay(100);
+            //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", power_save_freq_mhz);
+            //setCpuFrequencyMhz(power_save_freq_mhz);
           }
         }
         else{
           ESP_LOGI(LOG_TAG,  "switching screen ON, new mCurrentState: %d", new_screen_state);
           if (power_save_enabled)
           {
-            ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", performance_freq_mhz);
-            setCpuFrequencyMhz(performance_freq_mhz);
+            ESP_LOGI(LOG_TAG,  "disabling power save features");
+            // increasing CPU frequency back to 240MHz is breaking wifi connection 
+            //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", performance_freq_mhz);
+            //setCpuFrequencyMhz(performance_freq_mhz);
+            //delay(100);
+            WiFi.setSleep(false);
           }
         }
 

--- a/main/touch/TouchDriver.ipp
+++ b/main/touch/TouchDriver.ipp
@@ -5,6 +5,7 @@
 #include "Arduino.h"
 #include <config/HID_Config.h>
 #include <tft/ScreenSaver.hpp>
+#include <SharedGlobalState.h>
 
 namespace gfx
 {
@@ -41,8 +42,10 @@ namespace gfx
           break;
         case TouchState::TouchStart:
           newState = TouchState::TouchRunning;
+          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchEnded:
+          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchRunning:
           newState = TouchState::TouchRunning;
@@ -63,6 +66,7 @@ namespace gfx
         case TouchState::TouchRunning:
         case TouchState::TouchStart:
           newState = TouchState::TouchEnded;
+          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchEnded:
           newState = TouchState::NoTouch;
@@ -110,11 +114,13 @@ namespace gfx
       if (isShortPress)
       {
         tapEvent.state = PressEvent::Tap;
+        sgs::sharedGlobalState.registerTap();
         return std::make_optional(tapEvent);
       }
       if (isLongPress)
       {
         tapEvent.state = PressEvent::LongPress;
+        sgs::sharedGlobalState.registerTap();
         return std::make_optional(tapEvent);
       }
     }

--- a/main/touch/TouchDriver.ipp
+++ b/main/touch/TouchDriver.ipp
@@ -42,10 +42,8 @@ namespace gfx
           break;
         case TouchState::TouchStart:
           newState = TouchState::TouchRunning;
-          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchEnded:
-          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchRunning:
           newState = TouchState::TouchRunning;
@@ -66,7 +64,6 @@ namespace gfx
         case TouchState::TouchRunning:
         case TouchState::TouchStart:
           newState = TouchState::TouchEnded;
-          //sgs::sharedGlobalState.registerTap();
           break;
         case TouchState::TouchEnded:
           newState = TouchState::NoTouch;

--- a/main/ui/UIWidgetBuilder.hpp
+++ b/main/ui/UIWidgetBuilder.hpp
@@ -54,7 +54,7 @@ namespace util
         }
         button->setTextColor(textColor);
         button->setImage(imagePath);
-        screenSaver.activate();
+        //screenSaver.activate();  // no longer needed as screen saver uses now idle timeout from last touch event 
       };
       return button;
     };


### PR DESCRIPTION
An initial version where screen saver timeout from the last touch event is managed by a shared state singleton. 
Additionally to turning the screen off the back light and power led are also turned off.
Screen saver also enables power save functions if configured (by default) to do so with settings:
screenSaverPowerSaveEnabled
In this version the only power save option activated is sleep mode for wifi. 
