### PR TITLE
6 external 5 v power

### DIFF
--- a/components/m5stackcore2/M5Core2/src/M5Touch.cpp
+++ b/components/m5stackcore2/M5Core2/src/M5Touch.cpp
@@ -131,17 +131,17 @@ Point M5Touch::getPressPoint() {
 void M5Touch::update() { read(); }
 
 void M5Touch::dump() {
-  uint8_t data[256] = {0};
-  ft6336(0x00, 0x80, data);
-  ft6336(0x80, 0x80, data + 0x80);
-  Serial.printf("\n     ");
-  for (uint8_t i = 0; i < 16; i++) Serial.printf(".%1X ", i);
-  Serial.printf("\n");
-  for (uint16_t i = 0; i < 0x100; i++) {
-    if (!(i % 16)) Serial.printf("\n%1X.   ", i / 16);
-    Serial.printf("%02X ", data[i]);
-  }
-  Serial.printf("\n\n\n");
+  // uint8_t data[256] = {0};
+  // ft6336(0x00, 0x80, data);
+  // ft6336(0x80, 0x80, data + 0x80);
+  // Serial.printf("\n     ");
+  // for (uint8_t i = 0; i < 16; i++) Serial.printf(".%1X ", i);
+  // Serial.printf("\n");
+  // for (uint16_t i = 0; i < 0x100; i++) {
+  //   if (!(i % 16)) Serial.printf("\n%1X.   ", i / 16);
+  //   Serial.printf("%02X ", data[i]);
+  // }
+  // Serial.printf("\n\n\n");
 }
 
 // HotZone class (for compatibility with older M5Core2 code)

--- a/data/config_example.json
+++ b/data/config_example.json
@@ -7,6 +7,9 @@
   "mqttusername": "",
   "mqttpasswd": "",
   "timezone": "CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00",
+  "powerFrom5vRailNotUsb": true,
+  "screenSaverPowerSaveEnabled": true,
+  "screenSaverMinutes": 1,
   "scenes": [{
     "name": "Living Room",
     "type": "Light",

--- a/main/AppScreen.ipp
+++ b/main/AppScreen.ipp
@@ -168,7 +168,7 @@ namespace gfx
   {
     std::lock_guard<std::mutex> guard(viewMutex);
     auto tapEvent = mNavigation.tapEvent();
-    // FIXME: screen saver is broken - activates on touch and not on timeout (automatically) and does not deactivate 
+
     if(mScreenSaver()){
       // screen saver returned IGNORE_TOUCH_ON_WAKEUP
       return;

--- a/main/config/PlatformInject.hpp
+++ b/main/config/PlatformInject.hpp
@@ -75,18 +75,22 @@ auto VibrationStop = []() {
 
   auto InitializePlatform = [](config::HardwareConfig HwConfig)
   {
+    M5Touch().begin();
+    
     auto axp = AXP192();   
     if (HwConfig.mPowerFrom5vRailNotUsb)
     {
       axp.begin(kMBusModeInput); // kMBusModeInput means powered by external 5v and NOT USB
+      Serial.println("platform: power via external 5V");
     }
     else
     {
       axp.begin(kMBusModeOutput);
+      Serial.println("platform: power via USB");
     }
 
     axp.SetLDOEnable(3,0); // disable vibration motor
-    M5Touch().begin();
+    
   };
   
 #else // Touch Screen

--- a/main/config/PlatformInject.hpp
+++ b/main/config/PlatformInject.hpp
@@ -4,6 +4,8 @@
 #include <touch/TouchDriver.h>
 #include <ui/PROGMEMIconDrawer.hpp>
 
+#include <model/HardwareConfig.hpp>
+
 //    _____  _            _______ ______ ____  _____  __  __ 
 //   |  __ \| |        /\|__   __|  ____/ __ \|  __ \|  \/  |
 //   | |__) | |       /  \  | |  | |__ | |  | | |__) | \  / |
@@ -35,7 +37,7 @@
   auto VibrationPulse = [](int duration_ms) {};
   auto VibrationStart = []() {};
   auto VibrationStop = []() {};
-  auto InitializePlatform = []() {};
+  auto InitializePlatform = [](config::HardwareConfig HwConfig) {};
 
 #elif defined(M5StackCore2)
   #include <tft/TFTM5StackDriver.hpp>
@@ -71,10 +73,18 @@ auto VibrationStop = []() {
     axp.SetLDOEnable(3, false);
   };
 
-  auto InitializePlatform = []()
+  auto InitializePlatform = [](config::HardwareConfig HwConfig)
   {
-    auto axp = AXP192();
-    axp.begin(kMBusModeOutput);
+    auto axp = AXP192();   
+    if (HwConfig.mPowerFrom5vRailNotUsb)
+    {
+      axp.begin(kMBusModeInput); // kMBusModeInput means powered by external 5v and NOT USB
+    }
+    else
+    {
+      axp.begin(kMBusModeOutput);
+    }
+
     axp.SetLDOEnable(3,0); // disable vibration motor
     M5Touch().begin();
   };
@@ -101,7 +111,7 @@ auto VibrationStop = []() {
     digitalWrite(TFT_LED, LOW);    // LOW to turn backlight on - pcb version 01-02-00
     driver->begin(320000000);
   }; // Screen initialization routines
-  auto InitializePlatform = []() {
+  auto InitializePlatform = [](config::HardwareConfig HwConfig) {
     ledcAttachPin(21,0);
   };
 #endif                          

--- a/main/fs/ConfigReader.cpp
+++ b/main/fs/ConfigReader.cpp
@@ -324,6 +324,13 @@ namespace fs
           }
         );
 
+      read(document, "powerFrom5vRailNotUsb", [&](bool powerFrom5vRailNotUsb)
+          {
+            ESP_LOGI(LOG_TAG,  "overriden powerFrom5vRailNotUsb to  %d", powerFrom5vRailNotUsb);
+            hwConfig.mPowerFrom5vRailNotUsb = powerFrom5vRailNotUsb;
+          }
+        );
+
       read(document, "screenRotationAngle", [&](int angle)
           {
             hwConfig.mScreenRotationAngle = angle;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,7 +46,7 @@ extern "C"
     ESP_ERROR_CHECK(ret);
 
     initArduino();
-    InitializePlatform();
+    InitializePlatform(mpAppContext->getModel().mHardwareConfig);
     Serial.begin(115200);
     setupApp();
   }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,16 +46,8 @@ extern "C"
     ESP_ERROR_CHECK(ret);
 
     initArduino();
-    InitializePlatform(mpAppContext->getModel().mHardwareConfig);
     Serial.begin(115200);
-    setupApp();
-  }
 
-  void setupApp()
-  {
-    mScreen.setupScreen();
-    xTaskCreateUniversal(runLoop, "loopTask", 4096, NULL, 1, &runLoopHandle, MAINLOOPCORE);
-    mScreen.showWarning("Initializing HomePoint");
     try
     {
       mpAppContext->setup();
@@ -66,6 +58,19 @@ extern "C"
       mScreen.registerWifiCallback();
       return;
     }
+    
+    InitializePlatform(mpAppContext->getModel().mHardwareConfig);
+    
+    setupApp();
+  }
+
+  void setupApp()
+  {
+    
+    mScreen.setupScreen();
+    xTaskCreateUniversal(runLoop, "loopTask", 4096, NULL, 1, &runLoopHandle, MAINLOOPCORE);
+    mScreen.showWarning("Initializing HomePoint");
+
     if (!mpAppContext->getModel().hasWifiCredentials())
     {
       mScreen.showWarning("AP: HomePoint-Config, IP: 192.168.99.1");
@@ -78,22 +83,51 @@ extern "C"
   void runLoop(void *pvParameters)
   {
     //esp_log_level_set("*", ESP_LOG_INFO);
-    int loop_delay_ms = 20;
+    int desired_loop_cycle_length_ms = 30;
     ESP_LOGI("main", "starting main loop");
-    long last_loop_ts = millis();
+    long loop_start_ts;
+    long loop_end_ts = loop_start_ts = millis();
+    int work_took_ms = 0;
+    int loop_time_with_delays_took_ms = 0;
+    int loops_cnt = 0;
     
     for(;;)
     {
+        loop_start_ts = millis();
+        
         if (loopTaskWDTEnabled)
         {
           esp_task_wdt_reset();
         }
         
         mScreen.draw();
-        sharedGlobalStateTickUptimeMs(sgs_instance, millis() - last_loop_ts);
-        last_loop_ts = millis();
-        //global_state->tickUptimeMs(loop_delay_ms);
-        delay(loop_delay_ms);
+        
+        sharedGlobalStateTickUptimeMs(sgs_instance, millis() - loop_end_ts);
+        
+        loop_end_ts = millis();
+        
+        //global_state->tickUptimeMs(desired_loop_cycle_length_ms);
+        work_took_ms = loop_end_ts - loop_start_ts; 
+        
+        if (work_took_ms < desired_loop_cycle_length_ms)
+        {
+          delay(desired_loop_cycle_length_ms-work_took_ms);
+        }
+        else
+        {
+          ESP_LOGI("main", "work_took_ms > desired_loop_cycle_length_ms");
+          ESP_LOGI("main", "work_took_ms: %d", work_took_ms);
+          delay(15);  //we still need 15ms to be sure next touch read is available
+        }
+
+        loop_time_with_delays_took_ms = millis() - loop_start_ts;
+        
+        if(loops_cnt % 100 == 0)
+        {
+          ESP_LOGI("main", "work_took_ms: %d", work_took_ms);
+          ESP_LOGI("main", "loop_time_with_delays_took_ms: %d", loop_time_with_delays_took_ms);
+        }
+        loops_cnt += 1;
     }
   }
 }

--- a/main/model/HardwareConfig.hpp
+++ b/main/model/HardwareConfig.hpp
@@ -14,6 +14,7 @@ namespace config
     bool mIsTouchYAxisInverted = kTOUCH_Y_AXIS_INVERTED;
     bool mIsDisplayColorInverted = kDISPLAY_INVERTED;
     bool mIsScreenSaverPowerSaveEnabled = true;
+    bool mPowerFrom5vRailNotUsb = true;
     int mPowerSaveFreq = 80;
     int mPerformanceFreq = 240;
   };

--- a/main/tft/ScreenSaver.hpp
+++ b/main/tft/ScreenSaver.hpp
@@ -41,12 +41,12 @@ namespace gfx
           //during_blink = true;
           for(;blinks_count>0; blinks_count-- )
           {
-            switchScreen(screen_off);
+            switchScreen(screen_off, without_power_save);
             delay(5);
             if (blinks_count == 0){
-              return switchScreen(screen_on);
+              return switchScreen(screen_on, without_power_save);
             }
-            switchScreen(screen_on);
+            switchScreen(screen_on, without_power_save);
             delay(50);
           }
         }
@@ -66,11 +66,11 @@ namespace gfx
 
         if (static_cast<int>(sgs::sharedGlobalState.getIdleTimeSec()) < static_cast<int>(timeOutMin) * 60 )
         {
-          return switchScreen(screen_on);
+          return switchScreen(screen_on, with_power_save);
         }
         else
         {
-          return switchScreen(screen_off);
+          return switchScreen(screen_off, with_power_save);
         }
       }
 
@@ -96,7 +96,7 @@ namespace gfx
 
     private:
 
-      bool switchScreen(bool new_screen_state)
+      bool switchScreen(bool new_screen_state, bool skip_power_save)
       {
         if (new_screen_state == mCurrentState)
         {
@@ -106,26 +106,28 @@ namespace gfx
         if (new_screen_state)
         {
           ESP_LOGI(LOG_TAG,  "switching screen OFF, new mCurrentState: %d", new_screen_state);
-          if (power_save_enabled)
-          {
-            ESP_LOGI(LOG_TAG,  "enabling power save features");
-            WiFi.setSleep(true);
-            //delay(100);
-            //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", power_save_freq_mhz);
-            //setCpuFrequencyMhz(power_save_freq_mhz);
-          }
+          if(!skip_power_save)
+            if (power_save_enabled)
+            {
+              ESP_LOGI(LOG_TAG,  "enabling power save features");
+              WiFi.setSleep(true);
+              //delay(100);
+              //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", power_save_freq_mhz);
+              //setCpuFrequencyMhz(power_save_freq_mhz);
+            }
         }
         else{
           ESP_LOGI(LOG_TAG,  "switching screen ON, new mCurrentState: %d", new_screen_state);
-          if (power_save_enabled)
-          {
-            ESP_LOGI(LOG_TAG,  "disabling power save features");
-            // increasing CPU frequency back to 240MHz is breaking wifi connection 
-            //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", performance_freq_mhz);
-            //setCpuFrequencyMhz(performance_freq_mhz);
-            //delay(100);
-            WiFi.setSleep(false);
-          }
+          if(!skip_power_save)
+            if (power_save_enabled)
+            {
+              ESP_LOGI(LOG_TAG,  "disabling power save features");
+              // increasing CPU frequency back to 240MHz is breaking wifi connection 
+              //ESP_LOGI(LOG_TAG,  "setting CPU freq to: %d", performance_freq_mhz);
+              //setCpuFrequencyMhz(performance_freq_mhz);
+              //delay(100);
+              WiFi.setSleep(false);
+            }
         }
 
         ScreenOnOffSwitch(mpDriver, new_screen_state, mpCtx->getModel().mHardwareConfig.mIsLEDPinInverted);
@@ -137,6 +139,8 @@ namespace gfx
       std::chrono::system_clock::time_point mLastTouch;
       const bool screen_on = false;
       const bool screen_off = true;
+      const bool with_power_save = false;
+      const bool without_power_save = true;
       bool mCurrentState = screen_on;  
       int last_log_print_sec = 0;
       int power_save_freq_mhz = 80;


### PR DESCRIPTION
implemented #6 with ugly change im main to support parsed config.

Also fixed issues with registering touches without any clear reason why started to fail every couple reboots after #6 was implemented; there is no more annoying multi-line debug log in serial console from M5Touch for each touch event.   

Fix for touch support possibly involves changing main loop execution to more stable intervals. Interval length is adjusted for typical touch update interval ~15ms. Probably in the future main loop interval length could be configurable with default value adjusted for each platform.

Blinking the screen on each touch (primitive feedback supplementing vibration) does not call any power saving functions (low power wifi at the moment).